### PR TITLE
Enhancements

### DIFF
--- a/bin/git-review.js
+++ b/bin/git-review.js
@@ -5,6 +5,7 @@ const chalk = require('chalk');
 const child_process = require('child_process');
 const debug = require('debug');
 const P = require('bluebird');
+const package = require('package-json-utils');
 const program = require('commander');
 const util = require('util');
 
@@ -51,6 +52,7 @@ async function parseArgs() {
   const parent = await nearestEpic();
   program
     .description('Review the current topic branch by files changed per commit')
+    .version(package.getVersion())
     .usage('[options]')
     .option('-b, --branch [committish]', `The committish the topic branch was created from [${parent}]`, parent)
     .option('-f, --by-file', 'Also output summary by file of files with multiple commits')

--- a/bin/git-review.js
+++ b/bin/git-review.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-'use strict';
 
 const _ = require('lodash');
 const chalk = require('chalk');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,85 @@
+{
+  "name": "gitreview",
+  "version": "1.0.3",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "requires": {
+        "color-convert": "1.9.1"
+      }
+    },
+    "bluebird": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+    },
+    "chalk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "requires": {
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.4.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "lodash": {
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "requires": {
+        "has-flag": "3.0.0"
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "requires": {
-        "color-convert": "1.9.1"
+        "color-convert": "^1.9.0"
       }
     },
     "bluebird": {
@@ -22,9 +22,9 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.4.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
     },
     "color-convert": {
@@ -32,7 +32,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.1.1"
       }
     },
     "color-name": {
@@ -58,6 +58,23 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
+    "file-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/file-match/-/file-match-1.0.2.tgz",
+      "integrity": "sha1-ycrSZdLIrfOoFHWw30dYWQafrvc=",
+      "requires": {
+        "utils-extend": "^1.0.6"
+      }
+    },
+    "file-system": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/file-system/-/file-system-2.2.2.tgz",
+      "integrity": "sha1-fWWDPjojR9zZVqgTxncVPtPt2Yc=",
+      "requires": {
+        "file-match": "^1.0.1",
+        "utils-extend": "^1.0.4"
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -73,13 +90,32 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "os": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/os/-/os-0.1.1.tgz",
+      "integrity": "sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M="
+    },
+    "package-json-utils": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/package-json-utils/-/package-json-utils-1.1.1.tgz",
+      "integrity": "sha1-Cgse+J+FMjqD/oEZYGL9NUlsIio=",
+      "requires": {
+        "file-system": "^2.2.2",
+        "os": "^0.1.1"
+      }
+    },
     "supports-color": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
       "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
       "requires": {
-        "has-flag": "3.0.0"
+        "has-flag": "^3.0.0"
       }
+    },
+    "utils-extend": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/utils-extend/-/utils-extend-1.0.8.tgz",
+      "integrity": "sha1-zP17ZFQPjpDuIe7Fd2nQZRyril8="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "gitreview",
   "version": "1.0.3",
   "description": "Review topic branch commits by files changed",
-  "bin": {"git-review": "./bin/git-review.js"},
+  "bin": {
+    "git-review": "./bin/git-review.js"
+  },
   "preferGlobal": true,
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -15,11 +17,11 @@
     "commits"
   ],
   "dependencies": {
-    "bluebird": "3.3.4",
-    "chalk": "^1.1.3",
-    "commander": "2.9.0",
-    "debug": "2.2.0",
-    "lodash": "4.13.1"
+    "bluebird": "3.5.1",
+    "chalk": "2.4.1",
+    "commander": "2.15.1",
+    "debug": "3.1.0",
+    "lodash": "4.17.10"
   },
   "author": "Jim Lloyd <jim@unitive.works>",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -24,15 +24,16 @@
     "lodash": "4.17.10",
     "package-json-utils": "^1.1.1"
   },
-  "author": "Jim Lloyd <jim@unitive.works>",
-  "license": "ISC",
+  "author": "Jim Lloyd <jim.lloyd@gmail.com>",
+  "license": "MIT",
   "devDependencies": {},
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/unitive-jim/gitreview.git"
+    "url": "git+https://github.com/jimlloyd/gitreview.git"
   },
   "bugs": {
-    "url": "https://github.com/unitive-jim/gitreview/issues"
+    "url": "https://github.com/jimlloyd/gitreview/issues"
   },
-  "homepage": "https://github.com/unitive-jim/gitreview#readme"
+  "homepage": "https://github.com/jimlloyd/gitreview#readme",
+  "main": "bin/git-review.js"
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "chalk": "2.4.1",
     "commander": "2.15.1",
     "debug": "3.1.0",
-    "lodash": "4.17.10"
+    "lodash": "4.17.10",
+    "package-json-utils": "^1.1.1"
   },
   "author": "Jim Lloyd <jim@unitive.works>",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gitreview",
   "version": "1.0.3",
   "description": "Review topic branch commits by files changed",
-  "bin": "./bin/gitreview",
+  "bin": {"git-review": "./bin/git-review.js"},
   "preferGlobal": true,
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
1. Installed as `git-review` instead of `gitreview`; no longer need to manually create the alias.
2. Infer the parent branch. Currently just chooses the nearest of [`master`, `develop`, `origin/master`, `origin/develop`].
3. Preserves the `short` decorations (`--decorate=short`).
4. Uses a range that includes the parent commit by using parent~1 in range.
5. Includes the program version in commander options.
6. Updated all `npm` package dependencies
7. Updated code to use `async`/`await`.
8. Moved from my defunct `unitive-jim` identity to my permanent identity `jimlloyd`.
